### PR TITLE
Fixes 2 issues

### DIFF
--- a/window-stool.el
+++ b/window-stool.el
@@ -318,7 +318,7 @@ See: \"window-stool-use-overlays\""
                  (window-stool-window--advise-window-functions))))
     ;; clean up overlay stuff
     (progn (remove-overlays (point-min) (point-max) 'type 'window-stool--buffer-overlay)
-           (remove-hook 'post-command-hook (lambda () (window-stool--scroll-overlay-into-position)) t)
+           (remove-hook 'post-command-hook #'window-stool--scroll-overlay-into-position t)
            (setq window-scroll-functions
                  (remove #'window-stool--scroll-function window-scroll-functions))
            (kill-local-variable 'scroll-margin)


### PR DESCRIPTION
1. fix `window-stool--scroll-overlay-into-position` not being removed from `post-command-hook`
2. fix idle timer not being cancelled

The second issue is kind of messy - I don't really know *why* the timer is not being cancelled.

The commit messages should be fairly descriptive of the issues being solved, so I'll forego repeating it here.

I'm happy to split this into two separate PR's if you would prefer.
